### PR TITLE
Updated config extraction, storing static path root directory

### DIFF
--- a/config
+++ b/config
@@ -1,3 +1,6 @@
 server {
   port 8080;
+  path /static {
+    root "/home/CS130";
+  }
 }

--- a/echo_server.cpp
+++ b/echo_server.cpp
@@ -17,14 +17,24 @@ int EchoServer::getPort(){
 
 bool EchoServer::extractConfig(std::string& errorMessage){
   
+  static_root = "";
   std::string str_port = "";
   for (auto statements : config_.statements_){
     if (statements->tokens_[0] == "server" && statements->child_block_ != nullptr){
       for (auto childStatement : statements->child_block_->statements_){
-        if (childStatement->tokens_[0] == "listen" || childStatement->tokens_[0] == "port"){
+	
+	//Extract port
+        if (childStatement->tokens_.size() >= 1 && (childStatement->tokens_[0] == "listen" || childStatement->tokens_[0] == "port")){
           str_port = childStatement->tokens_[1];
           port = stoi(str_port);
-	  break;
+        }
+	//Extract root dir for path /static
+        else if (childStatement->tokens_[0] == "path" && childStatement->tokens_[1] == "/static"){
+	  for (auto staticConfig : childStatement->child_block_->statements_){
+	    if (staticConfig->tokens_.size() >= 2 && staticConfig->tokens_[0] == "root"){
+	      static_root = staticConfig->tokens_[1];
+	    }
+	  }
         }
       } 
     }
@@ -34,6 +44,12 @@ bool EchoServer::extractConfig(std::string& errorMessage){
     errorMessage = "No port provided.";
     return false; 
   }
+
+  if (static_root == ""){
+    errorMessage = "No static root dir provided in config.";
+    return false;
+  }
+
   if (port < 0 || port > 65535){
     errorMessage = "Port given was outside of acceptable range (0 - 65535).";
     return false;
@@ -63,8 +79,7 @@ bool EchoServer::init(std::string& errorMessage){
 
 
 void EchoServer::run(){
-  std::cout << "Running echo_server..." << std::endl << std::endl;
-
+  std::cout << "Running echo_server with static root " << static_root << "..." << std::endl << std::endl;
   for(;;){
     boost::asio::ip::tcp::socket socket(io_service_);
     acceptor_.accept(socket);

--- a/echo_server.hpp
+++ b/echo_server.hpp
@@ -19,4 +19,5 @@ class EchoServer {
    boost::asio::ip::tcp::acceptor acceptor_;
    NginxConfig config_;
    int port;
+   std::string static_root;
 };

--- a/echo_server_main.cpp
+++ b/echo_server_main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char *argv[]){
   std::string errorMessage;
   bool successInit = server.init(errorMessage);
   if (!successInit){
-    std::cerr << "Server.init failed with error message: " << errorMessage;
+    std::cerr << "Server.init failed with error message: " << errorMessage << std::endl;
     return -1;
   }
 


### PR DESCRIPTION
Using:
 path /static { 
    ...config ... 
 } 
as the format for per-path configurations for the web server.

Storing the config details in echo_server private members.